### PR TITLE
Add auto-scroll chat setting

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -110,6 +110,18 @@ export function SettingsPanel({
               </div>
             )}
           </div>
+
+          <div className="flex items-center space-x-3">
+            <input
+              type="checkbox"
+              checked={settings.autoScroll}
+              onChange={(e) => onUpdate({ autoScroll: e.target.checked })}
+              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              Auto Scroll
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -4,7 +4,7 @@ import { Settings, defaultSettings } from '../types/settings';
 export function useSettings() {
   const [settings, setSettings] = useState<Settings>(() => {
     const saved = localStorage.getItem('chat-settings');
-    return saved ? JSON.parse(saved) : defaultSettings;
+    return saved ? { ...defaultSettings, ...JSON.parse(saved) } : defaultSettings;
   });
 
   useEffect(() => {

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -25,6 +25,12 @@ export function Chat() {
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
   const { settings, updateSettings } = useSettings();
 
+  React.useEffect(() => {
+    if (settings.autoScroll && messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [messages, settings.autoScroll]);
+
   const [playMessageSound] = useSound(MESSAGE_SENT_SOUND, {
     volume: 0.2,
     soundEnabled: settings.soundEnabled && settings.messageSound,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -3,6 +3,7 @@ export interface Settings {
   soundEnabled: boolean;
   messageSound: boolean;
   typingSound: boolean;
+  autoScroll: boolean;
 }
 
 export const defaultSettings: Settings = {
@@ -10,4 +11,5 @@ export const defaultSettings: Settings = {
   soundEnabled: true,
   messageSound: true,
   typingSound: true,
+  autoScroll: true,
 };


### PR DESCRIPTION
## Summary
- allow user to toggle auto scroll
- persist new setting via `useSettings`
- apply auto scrolling in Chat page
- enable auto scroll by default

## Testing
- `npm run lint` *(fails: cannot pass eslint due to existing issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e1b05fd948325ad8642d1cb9a2724